### PR TITLE
Suppress spell checking visible password fields on iOS

### DIFF
--- a/IdApp/IdApp.iOS/Effects/PasswordMaskTogglerEffect.cs
+++ b/IdApp/IdApp.iOS/Effects/PasswordMaskTogglerEffect.cs
@@ -55,6 +55,7 @@ namespace IdApp.iOS.Effects
 					this.TextField.SecureTextEntry = false;
 					this.TextField.AutocorrectionType = UITextAutocorrectionType.No;
 					this.TextField.AutocapitalizationType = UITextAutocapitalizationType.None;
+					this.TextField.SpellCheckingType = UITextSpellCheckingType.No;
 				}
 			}
 		}


### PR DESCRIPTION
Set `SpellCheckingType` to `No` as well when making the password visible.