### PR TITLE
[UnobservedTaskException] Await an async method

### DIFF
--- a/IdApp/IdApp.Android/Push/MessagingService.cs
+++ b/IdApp/IdApp.Android/Push/MessagingService.cs
@@ -386,12 +386,12 @@ namespace IdApp.Android.Push
 			try
 			{
 				IPushNotificationService PushService = Types.Instantiate<IPushNotificationService>(true);
-				await PushService?.NewToken(new TokenInformation()
+				await (PushService?.NewToken(new TokenInformation()
 				{
 					Service = PushMessagingService.Firebase,
 					Token = p0,
 					ClientType = ClientType.Android
-				});
+				}) ?? Task.CompletedTask);
 			}
 			catch (Exception ex)
 			{

--- a/IdApp/IdApp.Android/Push/MessagingService.cs
+++ b/IdApp/IdApp.Android/Push/MessagingService.cs
@@ -381,12 +381,12 @@ namespace IdApp.Android.Push
 			NotificationManager.Notify(100, notificationBuilder.Build());
 		}
 
-		public override void OnNewToken(string p0)
+		public override async void OnNewToken(string p0)
 		{
 			try
 			{
 				IPushNotificationService PushService = Types.Instantiate<IPushNotificationService>(true);
-				PushService?.NewToken(new TokenInformation()
+				await PushService?.NewToken(new TokenInformation()
 				{
 					Service = PushMessagingService.Firebase,
 					Token = p0,

--- a/IdApp/IdApp.iOS/AppDelegate.cs
+++ b/IdApp/IdApp.iOS/AppDelegate.cs
@@ -301,13 +301,13 @@ namespace IdApp.iOS
 		}
 
 		[Export("messaging:didReceiveRegistrationToken:")]
-        public void DidReceiveRegistrationToken(Messaging _, string FcmToken)
+        public async void DidReceiveRegistrationToken(Messaging _, string FcmToken)
         {
             try
             {
                 IPushNotificationService PushService = Types.Instantiate<IPushNotificationService>(true);
 
-                PushService?.NewToken(new TokenInformation()
+                await PushService?.NewToken(new TokenInformation()
                 {
                     Service = PushMessagingService.Firebase,
                     Token = FcmToken,

--- a/IdApp/IdApp.iOS/AppDelegate.cs
+++ b/IdApp/IdApp.iOS/AppDelegate.cs
@@ -5,6 +5,7 @@ using IdApp.Helpers;
 using IdApp.Services.Ocr;
 using IdApp.Services.Push;
 using System;
+using System.Threading.Tasks;
 using Tesseract.iOS;
 using UIKit;
 using UserNotifications;
@@ -307,12 +308,12 @@ namespace IdApp.iOS
             {
                 IPushNotificationService PushService = Types.Instantiate<IPushNotificationService>(true);
 
-                await PushService?.NewToken(new TokenInformation()
+                await (PushService?.NewToken(new TokenInformation()
                 {
                     Service = PushMessagingService.Firebase,
                     Token = FcmToken,
                     ClientType = ClientType.iOS
-                });
+                }) ?? Task.CompletedTask);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Without `await`, the outer `try` - `catch` block is almost useless because an exception can be thrown inside the asynchronous continuation, which will lead to an UnobservedTaskException if the continuation is not awaited.