### PR TITLE
[SMART-111] Chat images memory leak

### DIFF
--- a/IdApp/IdApp.Android/MainActivity.cs
+++ b/IdApp/IdApp.Android/MainActivity.cs
@@ -103,6 +103,13 @@ namespace IdApp.Android
 			}
 
 			global::Xamarin.Forms.Forms.Init(this, SavedInstanceState);
+			FFImageLoading.Forms.Platform.CachedImageRenderer.InitImageViewHandler();
+
+			FFImageLoading.Config.Configuration Configuration = FFImageLoading.Config.Configuration.Default;
+			Configuration.DiskCacheDuration = TimeSpan.FromDays(1);
+			FFImageLoading.ImageService.Instance.Initialize(Configuration);
+			FFImageLoading.ImageService.Instance.InvalidateCacheAsync(FFImageLoading.Cache.CacheType.Disk);
+
 			this.LoadApplication(new App());
 		}
 

--- a/IdApp/IdApp.Android/MainActivity.cs
+++ b/IdApp/IdApp.Android/MainActivity.cs
@@ -103,12 +103,16 @@ namespace IdApp.Android
 			}
 
 			global::Xamarin.Forms.Forms.Init(this, SavedInstanceState);
+
+			// This must be called after Xamarin.Forms.Forms.Init.
 			FFImageLoading.Forms.Platform.CachedImageRenderer.InitImageViewHandler();
 
 			FFImageLoading.Config.Configuration Configuration = FFImageLoading.Config.Configuration.Default;
 			Configuration.DiskCacheDuration = TimeSpan.FromDays(1);
 			FFImageLoading.ImageService.Instance.Initialize(Configuration);
-			FFImageLoading.ImageService.Instance.InvalidateCacheAsync(FFImageLoading.Cache.CacheType.Disk);
+
+			// Uncomment this to debug loading images from neuron (ensures that they are not loaded from cache).
+			// FFImageLoading.ImageService.Instance.InvalidateCacheAsync(FFImageLoading.Cache.CacheType.Disk);
 
 			this.LoadApplication(new App());
 		}

--- a/IdApp/IdApp.iOS/AppDelegate.cs
+++ b/IdApp/IdApp.iOS/AppDelegate.cs
@@ -42,6 +42,12 @@ namespace IdApp.iOS
 			Helpers.Svg.SvgImage.Init();
 			FFImageLoading.Forms.Platform.CachedImageRenderer.Init();
 			Xamarin.Forms.Forms.Init();
+			FFImageLoading.Forms.Platform.CachedImageRenderer.InitImageSourceHandler();
+
+			FFImageLoading.Config.Configuration Configuration = FFImageLoading.Config.Configuration.Default;
+			Configuration.DiskCacheDuration = TimeSpan.FromDays(1);
+			FFImageLoading.ImageService.Instance.Initialize(Configuration);
+			FFImageLoading.ImageService.Instance.InvalidateCacheAsync(FFImageLoading.Cache.CacheType.Disk);
 
 			this.LoadApplication(new App());
 

--- a/IdApp/IdApp.iOS/AppDelegate.cs
+++ b/IdApp/IdApp.iOS/AppDelegate.cs
@@ -42,12 +42,16 @@ namespace IdApp.iOS
 			Helpers.Svg.SvgImage.Init();
 			FFImageLoading.Forms.Platform.CachedImageRenderer.Init();
 			Xamarin.Forms.Forms.Init();
+
+			// This must be called after Xamarin.Forms.Forms.Init.
 			FFImageLoading.Forms.Platform.CachedImageRenderer.InitImageSourceHandler();
 
 			FFImageLoading.Config.Configuration Configuration = FFImageLoading.Config.Configuration.Default;
 			Configuration.DiskCacheDuration = TimeSpan.FromDays(1);
 			FFImageLoading.ImageService.Instance.Initialize(Configuration);
-			FFImageLoading.ImageService.Instance.InvalidateCacheAsync(FFImageLoading.Cache.CacheType.Disk);
+
+			// Uncomment this to debug loading images from neuron (ensures that they are not loaded from cache).
+			// FFImageLoading.ImageService.Instance.InvalidateCacheAsync(FFImageLoading.Cache.CacheType.Disk);
 
 			this.LoadApplication(new App());
 

--- a/IdApp/IdApp/Pages/Contacts/Chat/ChatPageIos.xaml.cs
+++ b/IdApp/IdApp/Pages/Contacts/Chat/ChatPageIos.xaml.cs
@@ -119,9 +119,9 @@ namespace IdApp.Pages.Contacts.Chat
 		{
 			private readonly WeakReference<ViewCell> weakViewCell;
 
-			public ImageSizeChangedHandler(WeakReference<ViewCell> weakViewCell)
+			public ImageSizeChangedHandler(WeakReference<ViewCell> WeakViewCell)
 			{
-				this.weakViewCell = weakViewCell;
+				this.weakViewCell = WeakViewCell;
 			}
 
 			public void HandleSizeChanged(object Sender, EventArgs EventArgs)


### PR DESCRIPTION
It seems that when using `ImageSource` derivatives from *FFImageLoading*, the leak does not occur. ¯\\_(ツ)_/¯