### PR TITLE
Add `https` scheme to `Info.plist`

### DIFF
--- a/IdApp/IdApp.iOS/Info.plist
+++ b/IdApp/IdApp.iOS/Info.plist
@@ -82,5 +82,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>https</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Although it is usually not necessary, for some iOS versions we need to add `https` scheme to `Info.plist` explicitly to make it work with Chrome as the default browser. See https://developer.apple.com/forums/thread/660241. It refused to work without these lines for me for iPhone SE (iOS 14.2).