### PR TITLE
Update `SvgUtility`

### DIFF
--- a/IdApp/IdApp/Helpers/Svg/SvgUtility.cs
+++ b/IdApp/IdApp/Helpers/Svg/SvgUtility.cs
@@ -44,7 +44,7 @@ namespace IdApp.Helpers.Svg
 
 			using SKImage Image = SKImage.FromBitmap(Bitmap);
 			using SKData Encoded = Image.Encode();
-			using MemoryStream ImageStream = new();
+			MemoryStream ImageStream = new(); // Heads up: we return this stream, hence no using here.
 
 			Encoded.SaveTo(ImageStream);
 			ImageStream.Position = 0;


### PR DESCRIPTION
Revert back the change introduced in fc31cf163fb88f4b83511123bb07d67f97f3fdee. Namely, replace back `using` variable declarations with the old `using` statements.