### PR TITLE
Update `CustomPickerRenderer`

### DIFF
--- a/IdApp/IdApp.Android/Renderers/CustomPickerRenderer.cs
+++ b/IdApp/IdApp.Android/Renderers/CustomPickerRenderer.cs
@@ -8,12 +8,13 @@ using IdApp.Android.Renderers;
 using IdApp.Helpers;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
+using Xamarin.Forms.Platform.Android.AppCompat;
 using AndroidColor = Android.Graphics.Color;
 
 [assembly: ExportRenderer(typeof(Picker), typeof(CustomPickerRenderer), new[] { typeof(VisualMarker.DefaultVisual) })]
 namespace IdApp.Android.Renderers
 {
-	public class CustomPickerRenderer : PickerRenderer
+	public class CustomPickerRenderer : PickerAppCompatRenderer
 	{
 		public CustomPickerRenderer(Context context) : base(context) { }
 


### PR DESCRIPTION
Inherit our `CustomPickerRenderer` from `PickerAppCompatRenderer` instead of `PickerRenderer`, which does not have an app compat look and feel.