### PR TITLE
Make an implicit style for `NavigationPage` apply to derived classes

### DIFF
--- a/IdApp/IdApp/App.xaml
+++ b/IdApp/IdApp/App.xaml
@@ -275,7 +275,7 @@
         </Style>
 
 		<!-- An explicit navigation page with a visible navigation header is displayed when scanning a QR code during on-boarding (when there is no Shell). -->
-		<Style TargetType="NavigationPage">
+		<Style TargetType="NavigationPage" ApplyToDerivedTypes="True">
 			<Setter Property="BarBackgroundColor" Value="{AppThemeBinding Dark={StaticResource HeadingBackgroundDarkTheme}, Default={StaticResource HeadingBackgroundLightTheme}}" />
 			<!-- Always using light theme color because this is what we use in Shell. -->
 			<Setter Property="BarTextColor" Value="{AppThemeBinding Dark={StaticResource HeadingForegroundLightTheme}, Default={StaticResource HeadingForegroundLightTheme}}" />


### PR DESCRIPTION
Set `ApplyToDerivedTypes` to `True` for an implicit style for `NavigationPage`. This has become necessary after we switched from
the usual `NavigationPage` to a derived class, `NavigationBasePage`.