### PR TITLE
Remove `OnDisappearingCompleted` and fix `BetweenMainPage`

### DIFF
--- a/IdApp/IdApp/App.xaml.cs
+++ b/IdApp/IdApp/App.xaml.cs
@@ -651,18 +651,17 @@ namespace IdApp
 			Page CurrentPage = this.MainPage is Shell Shell ? Shell.CurrentPage : this.MainPage;
 			if (CurrentPage is NavigationPage NavigationPage)
 				CurrentPage = NavigationPage.CurrentPage;
+			
+			if (CurrentPage is not Pages.Main.Loading.LoadingPage)
+			{
+				await CurrentPage.Navigation.PushModalAsync(new BetweenMainPage(), animated: false);
+			}
 
 			if (CurrentPage is ContentBasePage ContentBasePage)
 			{
 				await ContentBasePage.ViewModel.Disappearing();
 				await ContentBasePage.ViewModel.Dispose();
 			}
-
-			TaskCompletionSource<bool> OnDisappearingCompletedTaskSource = new();
-			((ContentBasePage)CurrentPage).OnDisappearingCompleted += (_, _) => OnDisappearingCompletedTaskSource.TrySetResult(true);
-
-			await CurrentPage.Navigation.PushModalAsync(new BetweenMainPage(), animated: false);
-			await OnDisappearingCompletedTaskSource.Task;
 
 			this.MainPage = Page;
 		}

--- a/IdApp/IdApp/IdApp.xml
+++ b/IdApp/IdApp/IdApp.xml
@@ -3518,11 +3518,6 @@
             </summary>
             <remarks>It also handles safe area insets for iOS applications, specifically on iPhones with the 'rabbit ear' displays.</remarks>
         </member>
-        <member name="E:IdApp.Pages.ContentBasePage.OnDisappearingCompleted">
-            <summary>
-            An event which is raised when <see cref="M:IdApp.Pages.ContentBasePage.OnDisappearing"/> has actually completed (normally or because of an exception).
-            </summary>
-        </member>
         <member name="M:IdApp.Pages.ContentBasePage.#ctor">
             <summary>
             Creates an instance of the <see cref="T:IdApp.Pages.ContentBasePage"/> class.

--- a/IdApp/IdApp/Pages/ContentBasePage.cs
+++ b/IdApp/IdApp/Pages/ContentBasePage.cs
@@ -17,11 +17,6 @@ namespace IdApp.Pages
     public class ContentBasePage : ContentPage
     {
 		/// <summary>
-		/// An event which is raised when <see cref="OnDisappearing"/> has actually completed (normally or because of an exception).
-		/// </summary>
-		public event EventHandler OnDisappearingCompleted;
-
-		/// <summary>
 		/// Creates an instance of the <see cref="ContentBasePage"/> class.
 		/// </summary>
 		protected internal ContentBasePage()
@@ -122,10 +117,6 @@ namespace IdApp.Pages
             catch (Exception ex)
             {
                 Log.Critical(ex);
-			}
-			finally
-			{
-				OnDisappearingCompleted?.Invoke(this, EventArgs.Empty);
 			}
         }
 


### PR DESCRIPTION
1.  When switching the application `MainPage`, we need to navigate to `BetweenMainPage` as the very first step, before we start to `await` something in order to prevent the user from messing up with the UI while we are awaiting.

2. Because `Disappearing` and `Dispose` are idempotent now, we don't need a fuss with `OnDisappearingCompleted` and can just await them before actually switching the `MainPage`.