### PR TITLE
Add a workaround for carousel current view size issue on Android

### DIFF
--- a/IdApp/IdApp/IdApp.xml
+++ b/IdApp/IdApp/IdApp.xml
@@ -9035,6 +9035,9 @@
             Overridden to sync the view with the view model when the page appears on screen.
             </summary>
         </member>
+        <member name="M:IdApp.Pages.Registration.Registration.RegistrationPage.OnDisappearingAsync">
+            <inheritdoc />
+        </member>
         <member name="M:IdApp.Pages.Registration.Registration.RegistrationPage.UpdateUiStep">
             This is a hack. The issue is that the Carousel view doesn't reflect the CurrentStep binding correctly in the UI.
             The viewmodel is correct. The position property on the CarouselView is correct. But during restarts

--- a/IdApp/IdApp/Pages/Registration/Registration/RegistrationPage.xaml.cs
+++ b/IdApp/IdApp/Pages/Registration/Registration/RegistrationPage.xaml.cs
@@ -16,10 +16,14 @@ namespace IdApp.Pages.Registration.Registration
 	{
         private readonly IUiSerializer uiSerializer;
 
-        /// <summary>
-        /// Creates a new instance of the <see cref="RegistrationPage"/> class.
-        /// </summary>
-        private RegistrationPage()
+		// See OnDisappearingAsync for details why we need these.
+		private View currentView;
+		private Rectangle currentViewBoundsBeforeDisappearing;
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="RegistrationPage"/> class.
+		/// </summary>
+		private RegistrationPage()
         {
             NavigationPage.SetHasNavigationBar(this, false);
             this.uiSerializer = App.Instantiate<IUiSerializer>();
@@ -49,14 +53,47 @@ namespace IdApp.Pages.Registration.Registration
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(100));
 				this.UpdateUiStep();
+
+				// this.UpdateUiStep(); uses BeginInvokeOnMainThread, so does this code in order to ensure that VisibleViews collection has been updated.
+				this.uiSerializer.BeginInvokeOnMainThread(() =>
+				{
+					// See OnDisappearingAsync as to why this is done.
+					if (this.currentView is not null && this.CarouselView.VisibleViews.Count == 1 && this.CarouselView.VisibleViews[0] == this.currentView)
+					{
+						this.CarouselView.VisibleViews[0].Layout(this.currentViewBoundsBeforeDisappearing);
+
+						this.currentView = null;
+						this.currentViewBoundsBeforeDisappearing = default;
+					}
+				});
             }
         }
 
-        /// This is a hack. The issue is that the Carousel view doesn't reflect the CurrentStep binding correctly in the UI.
-        /// The viewmodel is correct. The position property on the CarouselView is correct. But during restarts
-        /// it still doesn't show the correct view template for that step. Instead it shows the last view template.
-        /// So here we scroll back and forth one step to get it to be in sync with the viewmodel.
-        private void UpdateUiStep()
+		/// <inheritdoc />
+		protected override Task OnDisappearingAsync()
+		{
+			// On Android, when we navigate from the registration page to a scan QR code page and return back, the size of the current view
+			// inside the carousel is incorrect, it is erroneously less than it was before the navigation (the size of the carousel itself).
+			// So, we memorize it now in order to restore it later.
+			if (this.CarouselView.VisibleViews.Count == 1)
+			{
+				this.currentView = this.CarouselView.VisibleViews[0];
+				this.currentViewBoundsBeforeDisappearing = this.currentView.Bounds;
+			}
+			else
+			{
+				this.currentView = null;
+				this.currentViewBoundsBeforeDisappearing = default;
+			}
+
+			return base.OnDisappearingAsync();
+		}
+
+		/// This is a hack. The issue is that the Carousel view doesn't reflect the CurrentStep binding correctly in the UI.
+		/// The viewmodel is correct. The position property on the CarouselView is correct. But during restarts
+		/// it still doesn't show the correct view template for that step. Instead it shows the last view template.
+		/// So here we scroll back and forth one step to get it to be in sync with the viewmodel.
+		private void UpdateUiStep()
         {
             this.uiSerializer.BeginInvokeOnMainThread(() =>
             {
@@ -76,5 +113,5 @@ namespace IdApp.Pages.Registration.Registration
 				}
             });
         }
-    }
+	}
 }


### PR DESCRIPTION
Add a workaround for Android to compensate incorrect layout of the carousel's current view after navigating back from a scan QR code page.